### PR TITLE
updated colormaps, parameters for updated concentration maps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,15 +23,15 @@ find_package(Python COMPONENTS Interpreter REQUIRED)
 message(STATUS "Found Python interpreter: ${Python_EXECUTABLE}")
 
 set(MRI_CONCENTRATION_DATA_FILE ${CMAKE_CURRENT_SOURCE_DIR}/data/mesh-data/mri_processed_data/sub-01/modeling/resolution32/data.vtu)
-set(MRI_T1_DATA_FILE ${CMAKE_CURRENT_SOURCE_DIR}/data/mri-dataset-pre-contrast-only/mri_dataset/sub-01/ses-01/anat/sub-01_ses-01_T1w.nii.gz)
+set(MRI_T1_DATA_FILE ${CMAKE_CURRENT_SOURCE_DIR}/data/mri-dataset-precontrast-only.zip/mri_dataset/sub-01/ses-01/anat/sub-01_ses-01_T1w.nii.gz)
 
 add_custom_command(
   OUTPUT ${MRI_CONCENTRATION_DATA_FILE} ${MRI_T1_DATA_FILE}
          ${CMAKE_CURRENT_SOURCE_DIR}/data/mesh-data
-         ${CMAKE_CURRENT_SOURCE_DIR}/data/mri-dataset-pre-contrast-only
+         ${CMAKE_CURRENT_SOURCE_DIR}/data/mri-dataset-precontrast-only.zip
   COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/bin/get_data.py --output ${CMAKE_CURRENT_SOURCE_DIR}/data
   BYPRODUCTS ${CMAKE_CURRENT_SOURCE_DIR}/data/mesh-data.zip
-             ${CMAKE_CURRENT_SOURCE_DIR}/data/mri-dataset-pre-contrast-only.zip
+             ${CMAKE_CURRENT_SOURCE_DIR}/data/mri-dataset-precontrast-only.zip
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -39,7 +39,7 @@ add_custom_target(download_mri_data
   DEPENDS ${MRI_CONCENTRATION_DATA_FILE}
           ${MRI_T1_DATA_FILE}
           ${CMAKE_CURRENT_SOURCE_DIR}/data/mesh-data
-          ${CMAKE_CURRENT_SOURCE_DIR}/data/mri-dataset-pre-contrast-only
+          ${CMAKE_CURRENT_SOURCE_DIR}/data/mri-dataset-precontrast-only.zip
 )
 
 # the application code is in the app/ subdirectory

--- a/app/params.input
+++ b/app/params.input
@@ -11,11 +11,11 @@ Verbosity = true
 
 [Problem]
 Name = diffusion
-SurfaceConductance = 2e-4 # in mm/s
-TransferCoeffToBlood = 1e-6 # in 1/s
-PorosityBrain = 0.2
-PorositySAS = 0.4
-DiffusionType = LiteratureIsotropic
+SurfaceConductance = 0.5e-4 # in mm/s
+TransferCoeffToBlood = 0.1e-6 # in 1/s
+PorosityBrain = 0.22
+PorositySAS = 0.55
+DiffusionType = DataTensor
 UseCurveFit = true
 DiffusionFactor = 1.0
 

--- a/bin/get_data.py
+++ b/bin/get_data.py
@@ -25,7 +25,7 @@ def main():
 
     for file in files:
         file_name = file["filename"]
-        if file_name not in ["mesh-data.zip", "mri-dataset-pre-contrast-only.zip"]:
+        if file_name not in ["mesh-data.zip", "mri-dataset-precontrast-only.zip"]:
             continue
 
         output_name = output_dir / Path(file_name)
@@ -38,7 +38,7 @@ def main():
 
     for file in files:
         file_name = file["filename"]
-        if file_name not in ["mesh-data.zip", "mri-dataset-pre-contrast-only.zip"]:
+        if file_name not in ["mesh-data.zip", "mri-dataset-precontrast-only.zip"]:
             continue
 
         output_unpack_dir = output_dir / Path(file_name.rstrip(".zip"))

--- a/post/map_to_mri.py
+++ b/post/map_to_mri.py
@@ -45,7 +45,7 @@ def get_vtk_files(root):
 if __name__ == '__main__':
     # read the PVD file which is an XML file that contains the list of VTK files
     vtk_files = get_vtk_files(ET.parse(f'{PREFIX}diffusion.pvd').getroot())
-    ref_filename = '../data/mri-dataset-pre-contrast-only/mri_dataset/sub-01/ses-01/anat/sub-01_ses-01_T1w.nii.gz'
+    ref_filename = '../data/mri-dataset-precontrast-only/mri_dataset/sub-01/ses-01/anat/sub-01_ses-01_T1w.nii.gz'
     ref_mri = sm.load_mri(ref_filename, dtype=np.single)
     print(f'Loaded reference MRI image from {ref_filename}')
 

--- a/post/plot_mapped_mri.py
+++ b/post/plot_mapped_mri.py
@@ -11,7 +11,7 @@ mpl.rcParams['savefig.pad_inches'] = 0
 
 if __name__ == '__main__':
     fig, axs = plt.subplots(2, len(TIME_STAMPS), figsize=(15, 6), frameon=False)
-    background_data = niifile_to_ndarray('../data/mri-dataset-pre-contrast-only/mri_dataset/sub-01/ses-01/anat/sub-01_ses-01_T1w.nii.gz')
+    background_data = niifile_to_ndarray('../data/mri-dataset-precontrast-only/mri_dataset/sub-01/ses-01/anat/sub-01_ses-01_T1w.nii.gz')
     for j in range(len(VTK_FIELDS)):
         for i, time_stamp in enumerate(TIME_STAMPS):
             overlay_images(
@@ -20,7 +20,7 @@ if __name__ == '__main__':
                 ax=axs[j][i],
                 #slicer_op=lambda img: img[:, :, 310].T,
                 slicer_op=lambda img: np.flipud(img[150, :, :].T),
-                min_val=0, max_val=0.05,
+                min_val=0, max_val=0.07,
             )
             axs[j][i].annotate(
                 f'{time_stamp/86400*24:.0f}h',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 matplotlib
 numpy
 click
-pyvista
+pyvista<0.45
+PyQt6
 nibabel
 simple_mri
 vtk


### PR DESCRIPTION
- Switched pre-contrast back to precontrast, as I had updated the filename.
- Updated parameters to a reasonable fit (images below) for new concentrations
- Changed colorscale for overlayed concentrations so the colors look the same as before
- Restricted pyvista version to fix issue with overlays being shifted relative to background.
- 
<img width="1080" height="432" alt="mapped_mri_small" src="https://github.com/user-attachments/assets/bf61a549-ab30-4801-b506-5c449beb1c9c" />
<img width="3488" height="2040" alt="image" src="https://github.com/user-attachments/assets/e4935c54-c7b6-4e2e-99d9-6c2a140e0c0a" />
